### PR TITLE
Adds gem rb-readline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
+  # fix console not opening b/c of conflict with RVM
+  gem 'rb-readline', '~> 0.5.3'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    rb-readline (0.5.3)
     rdoc (4.3.0)
     representable (2.3.0)
       uber (~> 0.0.7)
@@ -276,6 +277,7 @@ DEPENDENCIES
   pg
   pry (~> 0.10.3)
   rails (= 5.0.1.rc2)
+  rb-readline (~> 0.5.3)
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)


### PR DESCRIPTION
After adding RVM to fix outdated SSL certificate, could not open console b/c of
error: /Users/Adia/.rubies/ruby-2.3.0/lib/ruby/2.3.0/irb/completion.rb:10:in
equire':
dlopen(/Users/Adia/.rubies/ruby-2.3.0/lib/ruby/2.3.0/x86_64-darwin15/readline.bundle,
9): Library not loaded: /usr/local/opt/readline/lib/libreadline.6.dylib
(LoadError)
  Referenced from:
/Users/Adia/.rubies/ruby-2.3.0/lib/ruby/2.3.0/x86_64-darwin15/readline.bundle
  Reason: image not found -
/Users/Adia/.rubies/ruby-2.3.0/lib/ruby/2.3.0/x86_64-darwin15/readline.bundle.

Adds gem as a quick fix.