### PR TITLE
Includes recipe name in grocery list

### DIFF
--- a/app/controllers/grocery_lists_controller.rb
+++ b/app/controllers/grocery_lists_controller.rb
@@ -1,18 +1,18 @@
 class GroceryListsController < ApplicationController
   def new
-    note_title = EvernoteApi::NOTE_TITLE  
-    note_notebook = EvernoteApi::NOTE_NOTEBOOK 
+    note_title = EvernoteApiService::NOTE_TITLE
+    note_notebook = EvernoteApiService::NOTE_NOTEBOOK
     auth_token = ENV['PROD_AUTH_TOKEN']
-    evernote_host = EvernoteApi::EVERNOTE_HOST
+    evernote_host = EvernoteApiService::EVERNOTE_HOST
     # auth_token = ENV['SANDBOX_AUTH_TOKEN']
 
     sql_meal_plan_ids = SqlFormatter.sql_ids(params['meal_plan_ids'])
     shopping_list = MealPlan.shopping_list(sql_meal_plan_ids)
 
-    note_store = EvernoteApi.create_note_store(auth_token, evernote_host)
-    note_notebook_guid = EvernoteApi.create_note_notebook_guid(note_notebook, auth_token, note_store)
-    note_body = EvernoteApi.make_note_body(shopping_list) 
+    note_store = EvernoteApiService.create_note_store(auth_token, evernote_host)
+    note_notebook_guid = EvernoteApiService.create_note_notebook_guid(note_notebook, auth_token, note_store)
+    note_body = EvernoteApiService.make_note_body(shopping_list)
 
-    EvernoteApi.make_note(note_store, note_title, note_body, auth_token, note_notebook_guid)
+    EvernoteApiService.make_note(note_store, note_title, note_body, auth_token, note_notebook_guid)
   end
 end

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -5,9 +5,11 @@ class MealPlan < ActiveRecord::Base
 
   def self.shopping_list(sql_meal_plan_ids)
     RecipeIngredient.connection.select_all(
-      "SELECT SUM(quantity) AS total_quantity, units.name AS unit, ingredients.name
+      "SELECT SUM(quantity) AS total_quantity, units.name AS unit, ingredients.name, recipes.name AS recipe_name
         FROM recipe_ingredients
-        JOIN ingredients 
+        JOIN recipes
+        ON recipe_ingredients.recipe_id = recipes.id
+        JOIN ingredients
         ON recipe_ingredients.ingredient_id = ingredients.id
         JOIN locations
         ON ingredients.location_id = locations.id
@@ -16,18 +18,18 @@ class MealPlan < ActiveRecord::Base
         JOIN meal_plan_recipes
         ON recipe_ingredients.recipe_id = meal_plan_recipes.recipe_id
         WHERE meal_plan_recipes.meal_plan_id IN (#{sql_meal_plan_ids})
-        GROUP BY locations.ordering, ingredients.name, units.name
+        GROUP BY locations.ordering, ingredients.name, units.name, recipes.name
         ORDER BY locations.ordering
       "
     )
-  end 
+  end
 
   def nutrient_intake
     IngredientNutrient.connection.select_all(
-      "SELECT nutrients.id, nutrients.name, ingredient_nutrients.unit AS amt_consumed_unit, sum((value/100)*amount_in_grams) AS amt_consumed 
-        FROM ingredient_nutrients 
-        JOIN recipe_ingredients 
-        ON recipe_ingredients.ingredient_id = ingredient_nutrients.ingredient_id 
+      "SELECT nutrients.id, nutrients.name, ingredient_nutrients.unit AS amt_consumed_unit, sum((value/100)*amount_in_grams) AS amt_consumed
+        FROM ingredient_nutrients
+        JOIN recipe_ingredients
+        ON recipe_ingredients.ingredient_id = ingredient_nutrients.ingredient_id
         JOIN nutrients
         ON nutrients.id = ingredient_nutrients.nutrient_id
         JOIN meal_plan_recipes
@@ -36,18 +38,18 @@ class MealPlan < ActiveRecord::Base
         GROUP BY nutrients.id, nutrients.name, amt_consumed_unit
         ORDER BY nutrients.name
       "
-    ) 
-  end  
+    )
+  end
 
   def nutrient_intake_from_custom_food(food, nutrient_name)
     if recipes.pluck(:name).include?(food.name)
       if food.nutrition[nutrient_name].present?
         return food.nutrition[nutrient_name]
-      else 
+      else
         return 0
-      end 
-    else 
+      end
+    else
       return 0
-    end 
-  end 
-end 
+    end
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -14,23 +14,23 @@ class Recipe < ActiveRecord::Base
 
   def nutrient_intake
     IngredientNutrient.connection.select_all(
-      "SELECT nutrients.id, nutrients.name, ingredient_nutrients.unit AS amt_consumed_unit, sum((value/100)*amount_in_grams) AS amt_consumed 
-        FROM ingredient_nutrients 
-        JOIN recipe_ingredients 
-        ON recipe_ingredients.ingredient_id = ingredient_nutrients.ingredient_id 
+      "SELECT nutrients.id, nutrients.name, ingredient_nutrients.unit AS amt_consumed_unit, sum((value/100)*amount_in_grams) AS amt_consumed
+        FROM ingredient_nutrients
+        JOIN recipe_ingredients
+        ON recipe_ingredients.ingredient_id = ingredient_nutrients.ingredient_id
         JOIN nutrients
         ON nutrients.id = ingredient_nutrients.nutrient_id
         WHERE recipe_ingredients.recipe_id IN (#{id})
         GROUP BY nutrients.id, nutrients.name, amt_consumed_unit
         ORDER BY nutrients.name
       "
-    ) 
-  end  
+    )
+  end
 
   private
 
   def capitalize_recipe_name!
     word_array = self.name.split.each { |word| word.capitalize! }
     self.name = word_array.join(' ')
-  end 
+  end
 end

--- a/app/services/evernote_api_service.rb
+++ b/app/services/evernote_api_service.rb
@@ -1,7 +1,7 @@
 require "digest/md5"
 require 'evernote-thrift'
 
-module EvernoteApi
+module EvernoteApiService
   NOTE_TITLE = 'Grocery List'
   NOTE_NOTEBOOK = 'Shopping List'
   EVERNOTE_HOST = "www.evernote.com"
@@ -30,16 +30,16 @@ module EvernoteApi
       if notebook.name == note_notebook
         return notebook.guid
       end
-    end 
-  end 
+    end
+  end
 
   def self.make_note_body(results)
     list = ''
     results.each do |row|
-      list += "<en-todo/>#{row['total_quantity']} #{row['unit']} #{row['name']}<br/>"
-    end 
+      list += "<en-todo/>#{row['total_quantity']} #{row['unit']} #{row['name']} (#{row['recipe_name']})<br/>"
+    end
     list
-  end 
+  end
 
   def self.make_note(note_store, note_title, note_body, auth_token, note_notebook_guid)
     n_body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
@@ -49,7 +49,7 @@ module EvernoteApi
     our_note = Evernote::EDAM::Type::Note.new
     our_note.title = note_title
     our_note.content = n_body
-    our_note.notebookGuid = note_notebook_guid 
+    our_note.notebookGuid = note_notebook_guid
 
     begin
       note = note_store.createNote(auth_token, our_note)
@@ -63,4 +63,4 @@ module EvernoteApi
 
     note
   end
-end 
+end

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -98,10 +98,15 @@ RSpec.describe MealPlan, type: :model do
   end
 
   describe '.shopping_list' do
-    it 'returns contents of shopping list' do
+    it 'returns contents of shopping list and for which recipe' do
       grams_of_apple_in_recipe
       grams_of_peanut_butter_in_recipe
       grams_of_black_beans_in_recipe
+      FactoryGirl.create(
+        :recipe_ingredient,
+        recipe_id: recipe2.id,
+        ingredient_id: apple.id
+      )
       meal_plan_recipe
       meal_plan_recipe2
 
@@ -110,12 +115,13 @@ RSpec.describe MealPlan, type: :model do
       results = MealPlan.shopping_list(sql_meal_plan_ids)
 
       expected = [
-        [1, "fruit", "apple"],
-        [1, "fruit", "black_beans"],
-        [1, "fruit", "peanut butter"]
+        [1.0, "fruit", "apple", 'Buttery Apple Banana'],
+        [1.0, "fruit", "apple", 'Black Bean Soup'],
+        [1.0, "fruit", "black_beans", 'Black Bean Soup'],
+        [1.0, "fruit", "peanut butter", 'Buttery Apple Banana']
       ]
 
-      expect(results.rows).to eq(expected)
+      expect(results.rows).to match_array(expected)
     end
   end
 

--- a/spec/services/evernote_api_service_spec.rb
+++ b/spec/services/evernote_api_service_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe EvernoteApiService do
+  describe '.make_note_body' do
+    it 'returns list of grocery items with its recipe name' do
+      shopping_list = [
+        { 'total_quantity' => 1, 'unit' => 'fruit', 'name' => 'apple', 'recipe_name' => 'Buttery Apple Banana' },
+        { 'total_quantity' => 1, 'unit' => 'fruit', 'name' => 'apple', 'recipe_name' => 'Black Bean Soup' },
+        { 'total_quantity' => 1, 'unit' => 'can', 'name' => 'peanut butter', 'recipe_name' =>'Buttery Apple Banana' },
+        { 'total_quantity' => 1, 'unit' => 'jar', 'name' => 'black beans', 'recipe_name' => 'Black Bean Soup' },
+      ]
+
+      expected = "<en-todo/>1 fruit apple (Buttery Apple Banana)<br/><en-todo/>1 fruit apple (Black Bean Soup)<br/><en-todo/>1 can peanut butter (Buttery Apple Banana)<br/><en-todo/>1 jar black beans (Black Bean Soup)<br/>"
+      result = EvernoteApiService.make_note_body(shopping_list)
+
+      expect(result).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
Includes to group by recipe name as a final group by. If an ingredient is used
in multiple recipes, the ingredient will show up for as many times it belongs to
other recipes. Can instead use string aggregate function to only display
ingredient once, and include list of recipes it is used for.
Includes recipe name to grocery list, within parens
Appends Service to EvernoteApi's class name