### PR TITLE
Uses column number_of_recipes

### DIFF
--- a/app/controllers/google_calendar_generated_meal_plans_controller.rb
+++ b/app/controllers/google_calendar_generated_meal_plans_controller.rb
@@ -12,10 +12,10 @@ class GoogleCalendarGeneratedMealPlansController < ApplicationController
     mick_mealplan = GoogleCalendarApi.get_mealplan_from_calendar(ENV['MICK_CALENDAR_ID'], params['start_date'].to_time.iso8601)
 
     adia_new_rows = MealPlanRecipe.new_rows(
-      MealPlanRecipe.fetch_recipe_ids_with_flag(adia_mealplan)
+      MealPlanRecipe.add_recipe_ids_to_mealplan(adia_mealplan)
     ) + MealPlanRecipe::ADIA_TEMPLATE
     mick_new_rows = MealPlanRecipe.new_rows(
-      MealPlanRecipe.fetch_recipe_ids_with_flag(mick_mealplan)
+      MealPlanRecipe.add_recipe_ids_to_mealplan(mick_mealplan)
     ) + MealPlanRecipe::MICK_TEMPLATE
 
     adia_meal_plan.meal_plan_recipes.create(adia_new_rows)

--- a/app/controllers/meal_plan_recipes_controller.rb
+++ b/app/controllers/meal_plan_recipes_controller.rb
@@ -2,15 +2,13 @@ class MealPlanRecipesController < ApplicationController
   def create
     @recipes = Recipe.order(:name)
     @meal_plan = MealPlan.find(params[:meal_plan_id])
-    params[:meal_plan_recipe][:number_of_recipes].to_i.times do
-      @meal_plan.meal_plan_recipes.create(
-        recipe_id: params[:meal_plan_recipe][:recipe_id],
-        number_of_recipes: 1
-      )
-    end 
+    @meal_plan.meal_plan_recipes.create(
+      recipe_id: params[:meal_plan_recipe][:recipe_id],
+      number_of_recipes: params[:meal_plan_recipe][:number_of_recipes]
+    )
 
     redirect_to meal_plan_path(@meal_plan)
-  end 
+  end
 
   def destroy
     @meal_plan_recipe = MealPlanRecipe.find(params[:id])
@@ -18,12 +16,12 @@ class MealPlanRecipesController < ApplicationController
     @meal_plans = MealPlan.order(created_at: :desc).limit(2)
 
     render 'meal_plans/index'
-  end 
+  end
 
   private
-  
+
   def meal_plan_recipe_params
     params.require(:meal_plan_recipe).permit(:number_of_recipes, :recipe_id)
-  end 
-end 
+  end
+end
 

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -5,7 +5,7 @@ class MealPlan < ActiveRecord::Base
 
   def self.shopping_list(sql_meal_plan_ids)
     RecipeIngredient.connection.select_all(
-      "SELECT SUM(quantity) AS total_quantity, units.name AS unit, ingredients.name, STRING_AGG(distinct(recipes.name), '; ') AS recipe_names
+      "SELECT SUM(quantity*meal_plan_recipes.number_of_recipes) AS total_quantity, units.name AS unit, ingredients.name, STRING_AGG(distinct(recipes.name), '; ') AS recipe_names
         FROM recipe_ingredients
         JOIN recipes
         ON recipe_ingredients.recipe_id = recipes.id
@@ -26,7 +26,7 @@ class MealPlan < ActiveRecord::Base
 
   def nutrient_intake
     IngredientNutrient.connection.select_all(
-      "SELECT nutrients.id, nutrients.name, ingredient_nutrients.unit AS amt_consumed_unit, sum((value/100)*amount_in_grams) AS amt_consumed
+      "SELECT nutrients.id, nutrients.name, ingredient_nutrients.unit AS amt_consumed_unit, sum((value/100)*amount_in_grams*meal_plan_recipes.number_of_recipes) AS amt_consumed
         FROM ingredient_nutrients
         JOIN recipe_ingredients
         ON recipe_ingredients.ingredient_id = ingredient_nutrients.ingredient_id

--- a/app/models/meal_plan_recipe.rb
+++ b/app/models/meal_plan_recipe.rb
@@ -2,53 +2,35 @@ class MealPlanRecipe < ActiveRecord::Base
   belongs_to :recipe
   belongs_to :meal_plan
 
-  # number_of_recipes attribute is dead code at the moment.
   ADIA_TEMPLATE = [
     # yogurts
     { recipe_id: 7, number_of_recipes: 1 },
     # fried eggs
-    { recipe_id: 80, number_of_recipes: 1, first_day_recipe: true },
-    { recipe_id: 80, number_of_recipes: 1 },
+    { recipe_id: 80, number_of_recipes: 2, first_day_recipe: true },
     # hot chocolate
     { recipe_id: 52, number_of_recipes: 1 },
     # grapefruits
-    { recipe_id: 45, number_of_recipes: 1, first_day_recipe: true },
-    { recipe_id: 45, number_of_recipes: 1 },
-    { recipe_id: 45, number_of_recipes: 1 },
-    { recipe_id: 45, number_of_recipes: 1 },
-    { recipe_id: 45, number_of_recipes: 1 },
-    { recipe_id: 45, number_of_recipes: 1 },
-    { recipe_id: 45, number_of_recipes: 1 },
-    { recipe_id: 45, number_of_recipes: 1 },
+    { recipe_id: 45, number_of_recipes: 8, first_day_recipe: true },
     # roasted veggies
-    { recipe_id: 69, number_of_recipes: 1, first_day_recipe: true },
-    { recipe_id: 69, number_of_recipes: 1 },
+    { recipe_id: 69, number_of_recipes: 2, first_day_recipe: true },
   ]
 
   MICK_TEMPLATE = [
-    #yogurts
+    # yogurts
     { recipe_id: 13, number_of_recipes: 1 },
     # hot chocolate
     { recipe_id: 52, number_of_recipes: 1 },
-    # 3 apples
-    { recipe_id: 44, number_of_recipes: 1 },
-    { recipe_id: 44, number_of_recipes: 1 },
-    { recipe_id: 44, number_of_recipes: 1 },
-    # 3 carbonated waters
-    { recipe_id: 21, number_of_recipes: 1 },
-    { recipe_id: 21, number_of_recipes: 1 },
-    { recipe_id: 21, number_of_recipes: 1 }
+    # apples
+    { recipe_id: 44, number_of_recipes: 3 },
+    # carbonated waters
+    { recipe_id: 21, number_of_recipes: 3 },
   ]
 
-  def self.fetch_recipe_ids_with_flag(mealplan)
-    recipe_ids_with_flag = []
-    mealplan.each do |row|
-      recipe_ids_with_flag << {
-        recipe_id: Recipe.where(name: row[:recipe_name]).first.id,
-        first_day_recipe: row[:first_day_recipe]
-      }
+  def self.add_recipe_ids_to_mealplan(mealplan)
+    mealplan.keys.map do |key|
+      mealplan[key][:recipe_id] = Recipe.where(name: key).first.id
     end
-    recipe_ids_with_flag
+    mealplan
   end
 
   def self.fetch_first_day_recipe_names(mealplan_ids)
@@ -57,17 +39,10 @@ class MealPlanRecipe < ActiveRecord::Base
     ).pluck(:name)
   end
 
-  # Recipe.where({name: recipe_names}).pluck(:id).each do |recipe_id|
-    # I had to get rid of this optimization b/c it was calling unique on
-    #  recipe names
-  def self.new_rows(recipe_ids_with_flag)
+  def self.new_rows(mealplan_with_recipe_ids)
     meal_plan_recipe_rows = []
-    recipe_ids_with_flag.each do |row|
-      meal_plan_recipe_rows << {
-        recipe_id: row[:recipe_id],
-        number_of_recipes: 1,
-        first_day_recipe: row[:first_day_recipe]
-      }
+    mealplan_with_recipe_ids.each do |_, value|
+      meal_plan_recipe_rows << value
     end
     meal_plan_recipe_rows
   end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -14,23 +14,23 @@ class Recipe < ActiveRecord::Base
 
   def nutrient_intake
     IngredientNutrient.connection.select_all(
-      "SELECT nutrients.id, nutrients.name, ingredient_nutrients.unit AS amt_consumed_unit, sum((value/100)*amount_in_grams) AS amt_consumed 
-        FROM ingredient_nutrients 
-        JOIN recipe_ingredients 
-        ON recipe_ingredients.ingredient_id = ingredient_nutrients.ingredient_id 
+      "SELECT nutrients.id, nutrients.name, ingredient_nutrients.unit AS amt_consumed_unit, sum((value/100)*amount_in_grams) AS amt_consumed
+        FROM ingredient_nutrients
+        JOIN recipe_ingredients
+        ON recipe_ingredients.ingredient_id = ingredient_nutrients.ingredient_id
         JOIN nutrients
         ON nutrients.id = ingredient_nutrients.nutrient_id
         WHERE recipe_ingredients.recipe_id IN (#{id})
         GROUP BY nutrients.id, nutrients.name, amt_consumed_unit
         ORDER BY nutrients.name
       "
-    ) 
-  end  
+    )
+  end
 
   private
 
   def capitalize_recipe_name!
     word_array = self.name.split.each { |word| word.capitalize! }
     self.name = word_array.join(' ')
-  end 
+  end
 end

--- a/app/services/google_calendar_api.rb
+++ b/app/services/google_calendar_api.rb
@@ -13,10 +13,16 @@ module GoogleCalendarApi
   # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
 
   def self.get_mealplan_from_calendar(calendar_id, start_date)
-    mealplan = []
+    mealplan = {}
     get_calendar_events(calendar_id, start_date).items.each do | event |
       event.start.date.to_date == start_date.to_date ? flag = true : flag = false
-      mealplan << { recipe_name: event.summary, first_day_recipe: flag }
+      if mealplan.has_key?(event.summary)
+        mealplan[event.summary][:number_of_recipes] += 1
+      else
+        mealplan[event.summary] = {}
+        mealplan[event.summary][:first_day_recipe] = flag
+        mealplan[event.summary][:number_of_recipes] = 1
+      end
     end
     mealplan
   end

--- a/spec/models/meal_plan_recipe_spec.rb
+++ b/spec/models/meal_plan_recipe_spec.rb
@@ -1,26 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe MealPlanRecipe, type: :model do
-  describe '.fetch_recipe_ids_with_flag' do
-    it 'returns array of hashes of recipe id with flag' do
+  describe '.add_recipe_ids_to_mealplan' do
+    it 'returns mealplan with recipe ids' do
       recipe = FactoryGirl.create(:recipe)
-      mealplan = [{ recipe_name: recipe.name, first_day_recipe: true }]
+      mealplan = { recipe.name => { number_of_recipes: 2, first_day_recipe: true }}
+      expected =
+        { recipe.name =>
+         { number_of_recipes: 2, first_day_recipe: true, recipe_id: recipe.id }
+        }
 
-      expected = [{ recipe_id: recipe.id, first_day_recipe: true }]
-      results = MealPlanRecipe.fetch_recipe_ids_with_flag(mealplan)
+      results = MealPlanRecipe.add_recipe_ids_to_mealplan(mealplan)
 
-      expect(results).to match_array(expected)
+      expect(results).to eq(expected)
     end
   end
 
   describe '.new_rows' do
     it 'returns rows to create' do
-      recipe_ids_with_flag = [{ recipe_id: 2, first_day_recipe: true }]
+      mealplan_with_recipe_ids =
+        { 'Roasted Veggies' =>
+         { number_of_recipes: 2, first_day_recipe: true, recipe_id: 5 }
+        }
 
-      expected = [{ recipe_id: 2, number_of_recipes: 1, first_day_recipe: true }]
-      results = MealPlanRecipe.new_rows(recipe_ids_with_flag)
+      expected = [{ recipe_id: 5, number_of_recipes: 2, first_day_recipe: true }]
+      results = MealPlanRecipe.new_rows(mealplan_with_recipe_ids)
 
-      expect(results).to match_array(expected)
+      expect(results).to eq(expected)
     end
   end
 end

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -72,21 +72,16 @@ RSpec.describe MealPlan, type: :model do
     FactoryGirl.create(
       :meal_plan_recipe,
       recipe_id: recipe.id,
-      meal_plan_id: meal_plan.id
-    )
-  end
-  let(:meal_plan_recipe_dup) do
-    FactoryGirl.create(
-      :meal_plan_recipe,
-      recipe_id: recipe.id,
-      meal_plan_id: meal_plan.id
+      meal_plan_id: meal_plan.id,
+      number_of_recipes: 2
     )
   end
   let(:meal_plan_recipe2) do
     FactoryGirl.create(
       :meal_plan_recipe,
       recipe_id: recipe2.id,
-      meal_plan_id: meal_plan.id
+      meal_plan_id: meal_plan.id,
+      number_of_recipes: 1
     )
   end
 
@@ -103,7 +98,6 @@ RSpec.describe MealPlan, type: :model do
       grams_of_peanut_butter_in_recipe
       grams_of_black_beans_in_recipe
       meal_plan_recipe
-      meal_plan_recipe_dup
       meal_plan_recipe2
       FactoryGirl.create(
         :recipe_ingredient,
@@ -141,24 +135,7 @@ RSpec.describe MealPlan, type: :model do
         results = meal_plan.nutrient_intake
         total_zinc = results.first['amt_consumed']
 
-        expect(total_zinc).to eq(6.442)
-      end
-    end
-
-    context 'meal plan with recipe duplicates' do
-      it 'returns total nutrient intake' do
-        zinc_in_apple
-        zinc_in_peanut_butter
-        grams_of_apple_in_recipe
-        grams_of_peanut_butter_in_recipe
-
-        meal_plan_recipe
-        meal_plan_recipe_dup
-
-        results = meal_plan.nutrient_intake
-        total_zinc = results.first['amt_consumed']
-
-        expect(total_zinc).to eq(3.704)
+        expect(total_zinc).to eq(8.294)
       end
     end
   end
@@ -170,7 +147,8 @@ RSpec.describe MealPlan, type: :model do
       FactoryGirl.create(
         :meal_plan_recipe,
         recipe_id: food_recipe.id,
-        meal_plan_id: meal_plan.id
+        meal_plan_id: meal_plan.id,
+        number_of_recipes: 1
       )
     end
 


### PR DESCRIPTION
Instead of being able to use the column number_of_recipes to represent how many
of each recipe are in a meal plan, there is a meal plan recipe record per
recipe, regardless if it is a duplicate record. Amends queries to multiply by
number_of_recipes so that duplicate records are no longer necessary.

Changes made affect nutrient intake quantity, amount of ing to buy, creating mealplan from google calendar api