### PR TITLE
Adds include_blank for ingredient form

### DIFF
--- a/app/views/ingredients/_form.html.erb
+++ b/app/views/ingredients/_form.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="form-group">
       <%= f.label(:unit_id) %>
-      <%= f.collection_select(:unit_id, @units, :id, :name, { prompt: true }, 
+      <%= f.collection_select(:unit_id, @units, :id, :name, { include_blank: true },
                               class:"js-dropdown form-control") %>
     </div>
     <div class="form-group">


### PR DESCRIPTION
When an ingredient is added or updated without selecting a unit for its
measuring amount, the record is created with the first unit option as its unit
without indicating on the form. This happens because the units are selected
using a dropdown that does not have the html option, 'include_blank'. Adds this
option since an ingredient record doesn't need to be tied to a unit.